### PR TITLE
resolves #9: Resolved pytest-exception issue

### DIFF
--- a/pytest_expect/expect.py
+++ b/pytest_expect/expect.py
@@ -13,7 +13,7 @@ identifiers.
 import ast
 import os.path
 import sys
-
+import warnings
 import pytest
 import umsgpack
 from six import PY2, PY3, text_type, binary_type
@@ -49,7 +49,7 @@ def pytest_configure(config):
         try:
             exp.load_expectations()
         except:
-            config.warn("W1", "failed to load expectation file")
+            warnings.warn(pytest.PytestWarning("failed to load expectation file"))
 
 
 class ExpectationPlugin(object):
@@ -155,7 +155,7 @@ class ExpectationPlugin(object):
         fails = set()
 
         if version >= 0x0200:
-            self.config.warn("W1", "test expectation file in unsupported version")
+            warnings.warn(pytest.PytestWarning("test expectation file in unsupported version"))
         elif version >= 0x0100:
             xfail = state["expect_xfail"]
             for s in xfail:
@@ -168,7 +168,7 @@ class ExpectationPlugin(object):
                     except UnicodeEncodeError:
                         pass
         else:
-            self.config.warn("W1", "test expectation file in unsupported version")
+            warnings.warn(pytest.PytestWarning("test expectation file in unsupported version"))
         return fails
 
     def pytest_collectreport(self, report):


### PR DESCRIPTION
Resolved pytest-exception issue

The issue was because `Config.warn` is now deprecated. 
Reference: https://docs.pytest.org/en/latest/deprecations.html#config-warn-and-node-warn

Updated the suggested warning method in the doc. 
Reference: https://docs.pytest.org/en/latest/reference.html#pytest.deprecated_call