### PR TITLE
Explicitly require six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,8 @@ setup(
 
     install_requires=[
         "pytest",
-        "u-msgpack-python"
+        "six",
+        "u-msgpack-python",
     ],
 
     packages=["pytest_expect"],


### PR DESCRIPTION
six is imported but was not required.
In the past, it might have been transitively pulled in by pytest.